### PR TITLE
blacklist kitty and sixel if TERM_PROGAM contains "iTerm"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 ### Removed
 - feature kitty-offset in favor of SlicedImage and SlicedProtocol
 
+### Fixed
+- Blacklist Kitty protocol on iTerm2
+  ITerm2 has gained support for kitty, but does not seem to work with unicode-placeholders, at
+  least with ratatui-image's implementation.
+  https://gitlab.com/gnachman/iterm2/-/work_items/11766
+
 ## [10.0.8](https://github.com/ratatui/ratatui-image/compare/v10.0.7...v10.0.8) - 2026-04-30
 
 ### Added

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -120,10 +120,11 @@ impl Picker {
         let mut options_with_blacklist = options;
         let is_wezterm = env::var("WEZTERM_EXECUTABLE").is_ok_and(|s| !s.is_empty());
         let is_konsole = env::var("KONSOLE_VERSION").is_ok_and(|s| !s.is_empty());
-        if is_wezterm || is_konsole {
-            // WezTerm could use Sixel, but iTerm2 (detected later is better).
+        let is_iterm = env::var("TERM_PROGRAM").is_ok_and(|s| s.contains("iTerm"));
+        if is_wezterm || is_konsole || is_iterm {
+            // WezTerm could use Sixel, but iTerm2 (detected later) works better.
             // Konsole's Sixel implementation is buggy: https://github.com/ratatui/ratatui-image?tab=readme-ov-file#compatibility-matrix
-            // Neither implement the placeholder part of kitty correctly.
+            // None implements the placeholder part of kitty correctly.
             options_with_blacklist
                 .blacklist_protocols(vec![ProtocolType::Kitty, ProtocolType::Sixel]);
         }


### PR DESCRIPTION
It seems like iTerm2 supports kitty, but not the unicode-placeholders part, and reports support back from the CSI query.

Fixes #158