### PR TITLE
fix: widen before multiplying cell counts, not after

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,8 +413,8 @@ impl Resize {
         size: Size,
         background_color: Option<Rgba<u8>>,
     ) -> DynamicImage {
-        let width = (size.width * font_size.width) as u32;
-        let height = (size.height * font_size.height) as u32;
+        let width = u32::from(size.width) * u32::from(font_size.width);
+        let height = u32::from(size.height) * u32::from(font_size.height);
 
         // Resize/Crop/etc., fitting a multiple of font-size, but not necessarily the `size`.
         let mut image = self.resize_pixels(image, width, height);
@@ -470,8 +470,8 @@ impl Resize {
             && desired.height <= target.height
             && (current.is_none() || current == Some(desired))
         {
-            let width = (desired.width * font_size.width) as u32;
-            let height = (desired.height * font_size.height) as u32;
+            let width = u32::from(desired.width) * u32::from(font_size.width);
+            let height = u32::from(desired.height) * u32::from(font_size.height);
             if image.width() == width || image.height() == height {
                 return None;
             }

--- a/src/protocol/halfblocks.rs
+++ b/src/protocol/halfblocks.rs
@@ -79,8 +79,11 @@ impl Halfblocks {
 
     fn render_halfblocks(&self, hbs: &[HalfBlock], area: Rect, buf: &mut Buffer) {
         for (i, hb) in hbs.iter().enumerate() {
-            let x = i as u16 % self.size.width;
-            let y = i as u16 / self.size.width;
+            // `i` indexes the cell buffer and can exceed u16; narrowing it
+            // before the divide aliases every cell past 65535 back to the top
+            // left, so the bottom of a large image is never drawn.
+            let x = (i % usize::from(self.size.width)) as u16;
+            let y = (i / usize::from(self.size.width)) as u16;
             if x >= area.width || y >= area.height {
                 continue;
             }
@@ -131,6 +134,85 @@ mod tests {
         Image,
         protocol::{Protocol, halfblocks::Halfblocks},
     };
+
+    /// Every cell of a grid larger than `u16::MAX` must be drawn where it
+    /// belongs.
+    ///
+    /// `render_halfblocks` derived its coordinates as `i as u16 % width`, and `i`
+    /// indexes the cell buffer. Narrowing before the divide aliases every cell
+    /// past 65535 back to the top left, so a large image paints its own lower
+    /// rows over its top rows and never draws its bottom at all.
+    ///
+    /// The half-blocks are built here rather than encoded from an image, because
+    /// the defect is in this function's index arithmetic and nothing else.
+    /// `encode` is chafa's under the default features and `primitive`'s without,
+    /// and the two lay a picture out differently -- chafa fits and dithers where
+    /// primitive stretches -- so a test that reached an image through either
+    /// would be asserting the encoder's business rather than the renderer's, and
+    /// would hold for exactly one feature combination. Going straight at the data
+    /// makes it true for both.
+    #[test]
+    fn renders_every_cell_of_a_grid_larger_than_u16_max() {
+        use ratatui::{buffer::Buffer, layout::Rect, style::Color};
+
+        use crate::protocol::{ProtocolTrait, halfblocks::HalfBlock};
+
+        let size = Size::new(458, 144);
+        let cells = usize::from(size.width) * usize::from(size.height);
+        assert!(
+            cells > usize::from(u16::MAX),
+            "the grid must actually exceed the ceiling this is about: {cells}"
+        );
+
+        // Distinct colours for the first and last rows, so a cell drawn from the
+        // wrong index is unmistakable: under the narrowing bug the last row's
+        // half-blocks land back at the top and the bottom is never written.
+        let (first, last, middle) = (
+            Color::Rgb(255, 0, 0),
+            Color::Rgb(0, 0, 255),
+            Color::Rgb(0, 255, 0),
+        );
+        let data: Vec<HalfBlock> = (0..cells)
+            .map(|i| {
+                let row = i / usize::from(size.width);
+                let colour = if row == 0 {
+                    first
+                } else if row == usize::from(size.height) - 1 {
+                    last
+                } else {
+                    middle
+                };
+                HalfBlock {
+                    upper: colour,
+                    lower: colour,
+                    char: '\u{2580}',
+                }
+            })
+            .collect();
+
+        let hbs = Halfblocks { data, size };
+        let area = Rect::new(0, 0, size.width, size.height);
+        let mut buf = Buffer::empty(area);
+        hbs.render(area, &mut buf);
+
+        let top = buf.cell((10, 0)).expect("a cell on the first row").fg;
+        let bottom = buf
+            .cell((10, size.height - 1))
+            .expect("a cell on the last row")
+            .fg;
+
+        assert_ne!(bottom, Color::Reset, "the last row is drawn at all");
+        assert_eq!(
+            top, first,
+            "the first row is drawn from the first row's data"
+        );
+        assert_eq!(
+            bottom,
+            last,
+            "and the last row from the last -- its cells are indexed past {}",
+            u16::MAX
+        );
+    }
 
     #[test]
     fn render_image() {

--- a/src/protocol/halfblocks/primitive.rs
+++ b/src/protocol/halfblocks/primitive.rs
@@ -13,7 +13,7 @@ const SPACE: char = ' ';
 pub fn encode(img: &DynamicImage, size: Size) -> Vec<HalfBlock> {
     let img = img.resize_exact(
         size.width as u32,
-        (size.height * 2) as u32,
+        u32::from(size.height) * 2,
         FilterType::Triangle,
     );
 
@@ -23,7 +23,7 @@ pub fn encode(img: &DynamicImage, size: Size) -> Vec<HalfBlock> {
             lower: Color::Rgb(0, 0, 0),
             char: HALF_UPPER,
         };
-        (size.width * size.height) as usize
+        usize::from(size.width) * usize::from(size.height)
     ];
 
     for (y, row) in img.to_rgb8().rows().enumerate() {
@@ -120,5 +120,41 @@ impl HalfBlock {
                 (gray, gray, gray)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{ImageBuffer, Rgba};
+
+    /// A composite larger than `u16::MAX` cells must still encode.
+    ///
+    /// The buffer was allocated with `(size.width * size.height) as usize` — a
+    /// `u16` multiply, which wraps — while the write index was computed as
+    /// `x + (size.width as usize) * (y / 2)`, in `usize`, which does not. Below
+    /// the ceiling the two agree exactly; one cell past it the allocation is made
+    /// modulo 65536 while the loop still walks the true extent.
+    ///
+    /// Reported from a 458x144 pane (65952 cells): the allocation wrapped to 416
+    /// and the encoder panicked with "index out of bounds: the len is 416 but the
+    /// index is 416".
+    #[test]
+    fn encodes_a_grid_of_more_than_u16_max_cells() {
+        let img: DynamicImage =
+            ImageBuffer::from_pixel(64, 64, Rgba::<u8>([255, 0, 0, 255])).into();
+        let size = Size::new(458, 144);
+        assert!(
+            u32::from(size.width) * u32::from(size.height) > u32::from(u16::MAX),
+            "the case is only meaningful past the ceiling",
+        );
+
+        let data = encode(&img, size);
+
+        assert_eq!(
+            data.len(),
+            458 * 144,
+            "one entry per cell, not modulo 65536"
+        );
     }
 }

--- a/src/sliced.rs
+++ b/src/sliced.rs
@@ -244,8 +244,8 @@ impl SlicedProtocol {
 /// So this only is used for Iterm2.
 fn slice_rows(image: DynamicImage, font_size: FontSize, size: Size) -> (Vec<DynamicImage>, Size) {
     let image = image.resize(
-        (size.width * font_size.width).into(),
-        (size.height * font_size.height).into(),
+        u32::from(size.width) * u32::from(font_size.width),
+        u32::from(size.height) * u32::from(font_size.height),
         image::imageops::FilterType::Nearest,
     );
 


### PR DESCRIPTION
My project is currently using half-blocks to render pixelated graphics by using small font sizes. This results in large terminal windows, which gets tripped up with the u16 math operations. This is a minimal patch that widens u16 variables before the math ops.

----

Eight places multiply two `u16`s and widen the result, so each wraps instead of producing the value it is cast to.

### The reachable one

`protocol/halfblocks/primitive.rs` allocates

```rust
(size.width * size.height) as usize
```

then writes to it at

```rust
x + (size.width as usize) * (y / 2)
```

which is computed in `usize`. Below 65535 cells the two agree exactly. One cell past it the buffer is allocated modulo 65536 while the loop still walks the true extent, so `encode` indexes past its own end.

I hit this at a 458x144 pane — 65952 cells, allocated as 416:

```
thread 'main' panicked at src/protocol/halfblocks/primitive.rs:33:21:
index out of bounds: the len is 416 but the index is 416
```

458x144 is a 460x147 terminal with a one-cell border — an ordinary full-screen window at a small font. Halfblocks is also the backend most likely to be handed a very fine grid, since its resolution *is* the cell grid, so the ceiling is easier to reach here than anywhere else.

### The other seven

Same shape, in `cells * font_size`:

- `Resize::resize` and `Resize::needs_resize` (`src/lib.rs`) derive pixel dimensions from a cell count. These do not panic — they silently resize to a wrapped pixel dimension once the product passes 65535, which a large image reaches easily.
- `slice_rows` (`src/sliced.rs`) does the same before `.into()`.

### The change

Widen the operands rather than the product, uniformly. No behaviour change below the ceiling; no API change.

### Test

`encodes_a_grid_of_more_than_u16_max_cells` asserts one entry per cell at 458x144. It fails before the change in both profiles, with different faces — in debug, overflow-checks fire on the multiply itself; in release it wraps and the panic is the out-of-bounds index above.

Full suite passes with `--no-default-features --features image-defaults,crossterm` (19 tests) in both debug and release.