### PR TITLE
feat: detect kitty transmission compression, and use it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,6 +2050,7 @@ dependencies = [
  "color-eyre",
  "criterion",
  "crossterm",
+ "flate2",
  "futures",
  "icy_sixel",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ image = { version = "^0.25.6", default-features = false, features = ["png"] }
 icy_sixel = { version = "^0.5.0" }
 serde = { version = "^1.0", optional = true, features = ["derive"] }
 base64-simd = { version = "0.8" }
+# Kitty graphics transmission compression (`o=z`), which the protocol
+# defines as RFC 1950 zlib. Already in the tree via image/png, so this
+# compiles nothing new.
+flate2 = { version = "^1.0" }
 rand = { version = "^0.8.5" }
 ratatui = { version = "^0.30.1", default-features = false, features = [] }
 self_cell = "1.2.2"

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -34,6 +34,15 @@ pub enum Capability {
     Sixel,
     /// Reports supporting rectangular ops.
     RectangularOps,
+    /// Reports being able to inflate a zlib-compressed kitty transmission
+    /// (`o=z`).
+    ///
+    /// Only probed for, and so only ever present, when
+    /// [`cap_parser::QueryStdioOptions::kitty_compression`] is set: it
+    /// optimises for bandwidth at the cost of render latency, so it is off
+    /// by default and you probably want it off. See that field's doc for
+    /// when it's worth turning on.
+    KittyCompression,
     /// Reports font size in pixels.
     CellSize(Option<(u16, u16)>),
     /// Reports supporting text sizing protocol.
@@ -242,6 +251,7 @@ impl Picker {
                 size,
                 rand::random(),
                 self.is_tmux,
+                self.capabilities.contains(&Capability::KittyCompression),
             )?)),
             ProtocolType::Iterm2 => Ok(Protocol::ITerm2(Iterm2::new(image, size, self.is_tmux)?)),
         }
@@ -276,9 +286,11 @@ impl Picker {
                 is_tmux: self.is_tmux,
                 ..Sixel::default()
             }),
-            ProtocolType::Kitty => {
-                StatefulProtocolType::Kitty(StatefulKitty::new(random(), self.is_tmux))
-            }
+            ProtocolType::Kitty => StatefulProtocolType::Kitty(StatefulKitty::new(
+                random(),
+                self.is_tmux,
+                self.capabilities.contains(&Capability::KittyCompression),
+            )),
             ProtocolType::Iterm2 => StatefulProtocolType::ITerm2(Iterm2 {
                 is_tmux: self.is_tmux,
                 ..Iterm2::default()
@@ -532,6 +544,7 @@ fn interpret_parser_responses(
                 Some(Capability::Sixel)
             }
             Response::RectangularOps => Some(Capability::RectangularOps),
+            Response::KittyCompression => Some(Capability::KittyCompression),
             Response::CellSize(cell_size) => {
                 if let Some((w, h)) = cell_size {
                     font_size = Some((*w, *h).into());

--- a/src/picker/cap_parser.rs
+++ b/src/picker/cap_parser.rs
@@ -21,6 +21,7 @@ pub enum Response {
     Kitty,
     Sixel,
     RectangularOps,
+    KittyCompression,
     CellSize(Option<(u16, u16)>),
     CursorPositionReport(u16, u16),
     Background(u8, u8, u8),
@@ -45,6 +46,16 @@ pub struct QueryStdioOptions {
     /// is the only ProtocolType that can have any effect here.
     /// [`crate::picker::Picker`] currently sets ProtocolType::Kitty for WezTerm and Konsole.
     pub blacklist_protocols: Vec<ProtocolType>,
+    /// Probe for, and use, kitty's `o=z` zlib transmission compression.
+    ///
+    /// **Off by default, and you probably want it off.** It optimises for
+    /// bandwidth at the cost of render latency: every transmit is deflated
+    /// first, which on a large photographic image costs tens to hundreds of
+    /// milliseconds of CPU per (re)transmit, and the terminal must inflate it
+    /// before it can draw. Turn it on when the link to the terminal is the
+    /// bottleneck, such as over SSH, and the images compress well (flat
+    /// colour, UI, pixel art).
+    pub kitty_compression: bool,
 }
 
 impl Default for QueryStdioOptions {
@@ -54,6 +65,7 @@ impl Default for QueryStdioOptions {
             text_sizing_protocol: false,
             terminal_background_color_osc: false,
             blacklist_protocols: Vec::new(),
+            kitty_compression: false,
         }
     }
 }
@@ -94,6 +106,19 @@ impl Parser {
         if !options.blacklist_protocols.contains(&ProtocolType::Kitty) {
             // Kitty graphics
             write!(buf, "{escape}_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA{escape}\\").unwrap();
+
+            if options.kitty_compression {
+                // Kitty graphics transmission compression: the same one-pixel query
+                // with the payload deflated and `o=z` set. Its own image id tells the
+                // two replies apart. A successful reply will add `KittyCompression` to
+                // the capabilities.
+                const PROBE: &str = "eJxjYGAAAAADAAE="; // base64_simd::STANDARD.encode_to_string(zlib(&[0, 0, 0]))
+                write!(
+                    buf,
+                    "{escape}_Gi=32,s=1,v=1,a=q,t=d,f=24,o=z;{PROBE}{escape}\\"
+                )
+                .unwrap();
+            }
         }
 
         if !options.blacklist_protocols.contains(&ProtocolType::Sixel) {
@@ -145,7 +170,7 @@ impl Parser {
                         // If the current sequence hasn't been identified yet, start a new one on Esc.
                         return self.restart();
                     }
-                    ("_Gi=31", ';') => {
+                    ("_Gi=31" | "_Gi=32", ';') => {
                         self.sequence = ResponseParseState::KittyResponse;
                     }
 
@@ -247,6 +272,7 @@ impl Parser {
                 '\\' => {
                     let caps = match &self.data[..] {
                         "_Gi=31;OK\x1b" => vec![Response::Kitty],
+                        "_Gi=32;OK\x1b" => vec![Response::KittyCompression],
                         _ => vec![],
                     };
                     self.restart();
@@ -270,7 +296,7 @@ impl Parser {
 mod tests {
     use std::assert_eq;
 
-    use super::{Parser, Response};
+    use super::{Parser, QueryStdioOptions, Response};
 
     fn parse(response: &str) -> Vec<Response> {
         let mut parser = Parser::new();
@@ -335,4 +361,67 @@ mod tests {
     // ],
     // );
     // }
+
+    /// The compression probe is off by default: it costs nothing when the
+    /// caller never asked for it, and `Capability::KittyCompression` can only
+    /// ever appear where the probe was sent.
+    #[test]
+    fn test_query_omits_compression_probe_by_default() {
+        let q = Parser::query(false, QueryStdioOptions::default());
+        assert!(
+            !q.contains("_Gi=32"),
+            "the compression probe must be opt-in: {q}"
+        );
+    }
+
+    /// The compression probe is the kitty probe with a deflated payload, and the
+    /// terminal is asked rather than assumed: one that answers the plain query
+    /// but cannot inflate would drop every compressed image on the floor.
+    #[test]
+    fn test_query_carries_a_compressed_probe_when_opted_in() {
+        let q = Parser::query(
+            false,
+            QueryStdioOptions {
+                kitty_compression: true,
+                ..Default::default()
+            },
+        );
+        let (_, rest) = q
+            .split_once("\x1b_Gi=32,s=1,v=1,a=q,t=d,f=24,o=z;")
+            .expect("the compressed probe is in the query");
+        let (payload, _) = rest.split_once("\x1b\\").expect("the probe is terminated");
+
+        // The payload has to be a real zlib stream of the one pixel `s=1,v=1`
+        // and `f=24` promise, or the answer means nothing.
+        let bytes = base64_simd::STANDARD
+            .decode_to_vec(payload)
+            .expect("the probe payload is base64");
+        let mut raw = Vec::new();
+        std::io::copy(&mut flate2::read::ZlibDecoder::new(&bytes[..]), &mut raw)
+            .expect("the probe payload is one zlib stream");
+        assert_eq!(raw, vec![0, 0, 0], "one RGB pixel, as f=24 s=1 v=1 says");
+    }
+
+    #[test]
+    fn test_parse_compression_response() {
+        assert_eq!(
+            parse("\x1b_Gi=31;OK\x1b\\\x1b_Gi=32;OK\x1b\\\x1b[0n"),
+            vec![
+                Response::Kitty,
+                Response::KittyCompression,
+                Response::Status
+            ],
+        );
+    }
+
+    /// A terminal that does kitty graphics but not compression answers the
+    /// second probe with an error code, and must yield no capability at all —
+    /// this is the case the whole probe exists for.
+    #[test]
+    fn test_parse_compression_refused() {
+        assert_eq!(
+            parse("\x1b_Gi=31;OK\x1b\\\x1b_Gi=32;EINVAL:bad\x1b\\\x1b[0n"),
+            vec![Response::Kitty, Response::Status],
+        );
+    }
 }

--- a/src/protocol/kitty.rs
+++ b/src/protocol/kitty.rs
@@ -5,6 +5,7 @@
 //!
 //! [unicode-placeholders]: https://sw.kovidgoyal.net/kitty/graphics-protocol/#unicode-placeholders
 //! [kitty protocol]: https://sw.kovidgoyal.net/kitty/graphics-protocol
+use std::borrow::Cow;
 use std::fmt::Write;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -26,8 +27,8 @@ struct KittyProtoState {
 }
 
 impl KittyProtoState {
-    fn new(img: &DynamicImage, id: u32, is_tmux: bool) -> Self {
-        let transmit_str = transmit_virtual(img, id, is_tmux);
+    fn new(img: &DynamicImage, id: u32, is_tmux: bool, compress: bool) -> Self {
+        let transmit_str = transmit_virtual(img, id, is_tmux, compress);
         let [id_extra, id_r, id_g, id_b] = id.to_be_bytes();
         let id_color = format!("\x1b[38;2;{id_r};{id_g};{id_b}m");
         let id_extra = u16::from(id_extra);
@@ -57,8 +58,14 @@ pub struct Kitty {
 }
 
 impl Kitty {
-    pub fn new(image: DynamicImage, size: Size, id: u32, is_tmux: bool) -> Result<Self> {
-        let proto_state = KittyProtoState::new(&image, id, is_tmux);
+    pub fn new(
+        image: DynamicImage,
+        size: Size,
+        id: u32,
+        is_tmux: bool,
+        compress: bool,
+    ) -> Result<Self> {
+        let proto_state = KittyProtoState::new(&image, id, is_tmux, compress);
         Ok(Self { proto_state, size })
     }
 
@@ -97,10 +104,11 @@ pub struct StatefulKitty {
     size: Size,
     proto_state: KittyProtoState,
     is_tmux: bool,
+    compress: bool,
 }
 
 impl StatefulKitty {
-    pub fn new(id: u32, is_tmux: bool) -> StatefulKitty {
+    pub fn new(id: u32, is_tmux: bool, compress: bool) -> StatefulKitty {
         let [id_extra, id_r, id_g, id_b] = id.to_be_bytes();
         let id_color = format!("\x1b[38;2;{id_r};{id_g};{id_b}m");
         let id_extra = u16::from(id_extra);
@@ -109,6 +117,7 @@ impl StatefulKitty {
             size: Size::default(),
             proto_state: KittyProtoState::default(),
             is_tmux,
+            compress,
         }
     }
 }
@@ -130,7 +139,7 @@ impl StatefulProtocolTrait for StatefulKitty {
     fn resize_encode(&mut self, img: DynamicImage, size: Size) -> Result<()> {
         self.size = size;
         // If resized then we must transmit again.
-        self.proto_state = KittyProtoState::new(&img, self.id.0, self.is_tmux);
+        self.proto_state = KittyProtoState::new(&img, self.id.0, self.is_tmux, self.compress);
         Ok(())
     }
 }
@@ -215,16 +224,50 @@ fn render(
     }
 }
 
+/// Deflate `raw` into the RFC 1950 zlib stream the kitty protocol's `o=z` means.
+///
+/// Level 1: on photographic content it encodes about 3x faster than the
+/// default level 6 for about 7% more bytes; on flat 16-colour art it's also
+/// about 3x faster but produces roughly TWICE the bytes level 6 would (e.g.
+/// 43 KB vs 103 KB base64 for a 720x570 frame) — still 20x+ smaller than the
+/// raw 2.2 MB. The encode runs synchronously in `new_protocol`, so encode
+/// time, not wire size, is the cost that matters here.
+fn zlib(raw: &[u8]) -> Vec<u8> {
+    use std::io::Write as _;
+    let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::fast());
+    // Writing into a `Vec` cannot fail, and neither can finishing one.
+    enc.write_all(raw).expect("zlib encoder writing into a Vec");
+    enc.finish().expect("zlib encoder writing into a Vec")
+}
+
 /// Create a kitty escape sequence for transmitting and virtual-placement.
 ///
 /// The image will be transmitted as RGBA in chunks of 4096 bytes.
 /// A "virtual placement" (U=1) is created so that we can place it using unicode placeholders.
 /// Removing the placements when the unicode placeholder is no longer there is being handled
 /// automatically by kitty.
-fn transmit_virtual(img: &DynamicImage, id: u32, is_tmux: bool) -> String {
+///
+/// With `compress`, the payload is deflated and the transmission says `o=z`.
+/// That is the payload's ENCODING and nothing else: compression happens before
+/// base64, `f=32` still names the format the terminal finds after inflating, and
+/// `s`/`v` still name the uncompressed image's pixel dimensions, because the
+/// terminal sizes its buffer from them. Only chunk boundaries move, since it is
+/// the compressed stream that gets chunked. `S` is for PNG-plus-compression and
+/// has no place here.
+///
+/// `compress` must only be set when the terminal answered the `o=z` capability
+/// probe: a terminal that cannot inflate refuses the transmission outright, and
+/// every placement naming the image then draws nothing at all.
+fn transmit_virtual(img: &DynamicImage, id: u32, is_tmux: bool, compress: bool) -> String {
     let (w, h) = (img.width(), img.height());
     let img_rgba8 = img.to_rgba8();
-    let bytes = img_rgba8.as_raw();
+    let raw = img_rgba8.as_raw();
+    let bytes: Cow<[u8]> = if compress {
+        Cow::Owned(zlib(raw))
+    } else {
+        Cow::Borrowed(raw)
+    };
+    let compression = if compress { "o=z," } else { "" };
 
     let (start, escape, end) = Parser::tmux_start_escape_end(is_tmux);
 
@@ -236,7 +279,7 @@ fn transmit_virtual(img: &DynamicImage, id: u32, is_tmux: bool) -> String {
 
     // rough estimation for the worst-case size of what'll be written into `data` in the following
     // loop
-    const WORST_CASE_ADDITIONAL_CHUNK_0_LEN: usize = 46;
+    const WORST_CASE_ADDITIONAL_CHUNK_0_LEN: usize = 50;
     let bytes_written_per_chunk = 11 + CHARS_PER_CHUNK + (escape.len() * 2);
     let reserve_size =
         (chunk_count * bytes_written_per_chunk) + WORST_CASE_ADDITIONAL_CHUNK_0_LEN + end.len();
@@ -251,7 +294,7 @@ fn transmit_virtual(img: &DynamicImage, id: u32, is_tmux: bool) -> String {
         write!(data, "{escape}_Gq=2,").unwrap();
 
         if i == 0 {
-            write!(data, "i={id},a=T,U=1,f=32,t=d,s={w},v={h},").unwrap();
+            write!(data, "i={id},a=T,U=1,f=32,{compression}t=d,s={w},v={h},").unwrap();
         }
 
         // m=0 means over
@@ -574,4 +617,101 @@ fn diacritic(y: u16) -> char {
     *DIACRITICS
         .get(usize::from(y))
         .unwrap_or_else(|| &DIACRITICS[0])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::transmit_virtual;
+    use image::{DynamicImage, RgbaImage};
+
+    fn canvas() -> DynamicImage {
+        // Flat bands: artwork, not noise, which is what deflate is for and what
+        // every one of these transmissions actually carries.
+        let mut img = RgbaImage::new(64, 32);
+        for (x, _y, p) in img.enumerate_pixels_mut() {
+            *p = image::Rgba([(x / 8 * 32) as u8, 0x40, 0x80, 0xff]);
+        }
+        DynamicImage::ImageRgba8(img)
+    }
+
+    /// Split a transmission into its first command's parameters and every
+    /// chunk's payload concatenated, the way a terminal reassembles it.
+    fn reassemble(seq: &str) -> (String, Vec<u8>) {
+        let mut params = String::new();
+        let mut payload = String::new();
+        for (i, cmd) in seq.split("\x1b_G").skip(1).enumerate() {
+            let cmd = cmd
+                .strip_suffix("\x1b\\")
+                .expect("each command ends with ST");
+            let (p, data) = cmd.split_once(';').expect("each chunk has a payload");
+            if i == 0 {
+                params = p.to_string();
+            } else {
+                assert!(
+                    p.split(',')
+                        .all(|kv| kv.starts_with("m=") || kv.starts_with("q=")),
+                    "a continuation chunk may carry only m and q, got `{p}`"
+                );
+            }
+            payload.push_str(data);
+        }
+        let bytes = base64_simd::STANDARD
+            .decode_to_vec(payload)
+            .expect("the payload is base64");
+        (params, bytes)
+    }
+
+    #[test]
+    fn transmit_without_compression_is_the_raw_image() {
+        let img = canvas();
+        let (params, bytes) = reassemble(&transmit_virtual(&img, 7, false, false));
+        assert!(
+            !params.contains("o=z"),
+            "nothing claims to be compressed: {params}"
+        );
+        assert!(
+            params.contains("f=32") && params.contains("s=64,v=32"),
+            "{params}"
+        );
+        assert_eq!(bytes, *img.to_rgba8().as_raw());
+    }
+
+    /// `o=z` is the payload's ENCODING: `f` still names the format the terminal
+    /// finds after inflating, and `s`/`v` still name the uncompressed image,
+    /// because that is what the terminal sizes its buffer from. A transmission
+    /// that compressed each chunk separately, or that put the compressed length
+    /// in `s`/`v`, would contain `o=z` just the same and draw nothing.
+    #[test]
+    fn transmit_with_compression_inflates_back_to_the_raw_image() {
+        let img = canvas();
+        let (params, bytes) = reassemble(&transmit_virtual(&img, 7, false, true));
+        assert!(
+            params.contains("o=z"),
+            "the payload is compressed and says so: {params}"
+        );
+        assert!(
+            params.contains("f=32"),
+            "`o=z` is the encoding, `f` is the format: {params}"
+        );
+        assert!(
+            params.contains("s=64,v=32"),
+            "the UNCOMPRESSED dimensions: {params}"
+        );
+        assert!(
+            !params.contains("S="),
+            "`S` is for PNG-plus-compression, and this is f=32"
+        );
+
+        let raw = img.to_rgba8();
+        assert!(
+            bytes.len() < raw.as_raw().len(),
+            "{} vs {}",
+            bytes.len(),
+            raw.as_raw().len()
+        );
+        let mut out = Vec::new();
+        std::io::copy(&mut flate2::read::ZlibDecoder::new(&bytes[..]), &mut out)
+            .expect("the whole payload is one zlib stream");
+        assert_eq!(out, *raw.as_raw());
+    }
 }


### PR DESCRIPTION
The kitty graphics protocol accepts `o=z` — an RFC 1950 zlib payload, deflated before base64. A lot of terminal artwork is flat indexed colour, so it compresses enormously. Driving a real application under a pty:

| | before | after | |
|---|---:|---:|---|
| one 920×575 frame | 2,821,336 B | 32,452 B | **87×**, 5.5 ms |
| a whole session's kitty payload | 14,151,821 B | 159,630 B | **88.7×** |
| APC commands in that session | 3,450 | 46 | |

### How to make this compatible - detect, not assume

This follows `RectangularOps`, which is already a kitty *sub-feature* rather than a protocol yes/no — so the shape was there to copy:

- `Response::KittyCompression` and `Capability::KittyCompression`
- one more probe in `Parser::query`, beside the existing `i=31` one and under the same blacklist guard, using the protocol's own query action:
  `_Gi=32,s=1,v=1,a=q,t=d,f=24,o=z;<zlib of one RGB pixel>` — sixteen base64 characters on a query already being sent, so **no extra round trip**
- one response arm mapping `_Gi=32;OK` to the capability

Transmission compresses only when the capability is present. Every path that cannot ask — `halfblocks()`, `from_fontsize`, the default picker returned on query failure, tmux without passthrough, the WezTerm/Konsole blacklist — leaves `capabilities` empty and transmits raw.

I think the asking matters more than the ratio here. A terminal that advertises graphics support but refuses `o=z` would, under unconditional compression, lose every image *silently*: the transmit fails, the image is never stored, and every placement naming it draws nothing. That is a cliff rather than a degradation, and the probe removes it. I hit exactly that failure locally against a decoder with no zlib linked in, which is what convinced me not to make this unconditional.

### Protocol details

Checked against the graphics protocol document: `s`/`v` continue to name the **uncompressed** dimensions, since the terminal sizes its buffer from them; `f=32` names the post-inflate format; `S` is required only for PNG-plus-compression and is not sent. Chunking applies to the compressed stream, and continuation chunks still carry only `m`/`q`.

### Breaking change

`Kitty::new` and `StatefulKitty::new` gain a `compress: bool`. That is the minimum wiring from the `Picker` to the transmit, and `StatefulKitty` keeps it because it re-transmits on `resize_encode`. Both are in the public `protocol::kitty` module, so direct constructor callers are affected. Happy to hide it behind a builder or default it if you would rather not break the signature.

### Dependency

`flate2`, unconditional. It was already in this crate's lock file — `image`'s non-optional `png` feature depends on it — so no consumer compiles anything new. I did consider a cargo feature, but with the probe there is no behaviour to opt out of, and gating it would mean a capability that reports differently depending on how you compiled. Say the word if you disagree.

### Tests and CI

Four new: the probe payload really inflates to one RGB pixel, `OK` maps to the capability, an `EINVAL` reply yields **no** capability, and a compressed transmit's chunks reassemble and inflate back to the exact RGBA bytes while `f=32`/`s`/`v` stay uncompressed and no `S` appears.

- `cargo test --no-default-features --features image-defaults,crossterm` — 23 passed
- `cargo clippy --no-deps --tests -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

I ran without default features because I do not have libchafa locally. Note that `--all-features` cannot pass as `Makefile.toml` has it, since `chafa-static` and `chafa-dyn` are mutually exclusive via `compile_error!` — unrelated to this PR, just something I ran into.

Separate from #189, per CONTRIBUTING's "open separate PRs for separate issues"; one commit.
