### PR TITLE
Derive `Eq` for `ProtocolType`

### DIFF
--- a/src/picker.rs
+++ b/src/picker.rs
@@ -54,7 +54,7 @@ pub struct Picker {
 }
 
 /// Serde-friendly protocol-type enum for [Picker].
-#[derive(PartialEq, Clone, Debug, Copy)]
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
 #[cfg_attr(
     feature = "serde",
     derive(Deserialize, Serialize),


### PR DESCRIPTION
I want to use `ProtocolType` in an `iamb` type that needs it to be `Eq`. I don't see how deriving this could lead to any problems.