### PR TITLE
Probe for kitty shared memory before using it (and make t=s work on macOS)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ thiserror = { version = "1.0.59" }
 tokio = { version = "1.45.1", default-features = false, optional = true, features = ["sync"]}
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "^0.38.4", features = ["stdio", "termios", "fs", "shm"] }
+rustix = { version = "^0.38.4", features = ["stdio", "termios", "fs", "shm", "mm"] }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.58.0", default-features = false, features = [

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -43,6 +43,15 @@ pub enum Capability {
     /// by default and you probably want it off. See that field's doc for
     /// when it's worth turning on.
     KittyCompression,
+    /// Reports being able to read a kitty transmission from a POSIX shared memory
+    /// object (`t=s`), which only a terminal on this machine can do.
+    ///
+    /// Probed for, and so only ever present, whenever
+    /// [`cap_parser::QueryStdioOptions::kitty_shared_memory_object`] is set: the
+    /// stdio query itself writes a real object and asks the terminal to read it
+    /// back, and [`Picker`] uses shared memory for its own transmissions only
+    /// where this capability is present.
+    KittySharedMemory,
     /// Reports font size in pixels.
     CellSize(Option<(u16, u16)>),
     /// Reports supporting text sizing protocol.
@@ -141,6 +150,11 @@ impl Picker {
                     .or(iterm2_proto)
                     .unwrap_or(ProtocolType::Halfblocks);
 
+                let kitty_shm = if caps.contains(&Capability::KittySharedMemory) {
+                    kitty_shm
+                } else {
+                    None
+                };
                 if let Some(font_size) = font_size {
                     Ok(Self {
                         font_size,
@@ -167,7 +181,8 @@ impl Picker {
                     tmux_proto.or_else(iterm2_from_env),
                     font_size_fallback(),
                 );
-                p.kitty_shm = kitty_shm;
+                // Nothing answered at all, so no capability was reported.
+                p.kitty_shm = None;
                 Ok(p)
             }
             Err(err) => Err(err),
@@ -497,7 +512,17 @@ fn query_stdio_capabilities(
     // `[1337n`: iTerm2 (some terminals implement the protocol but sadly not this custom CSI)
     // `[5n`: Device Status Report, implemented by all terminals, ensure that there is some
     // response and we don't hang reading forever.
-    let query = Parser::query(is_tmux, options);
+    let (query, shm_probe_name) = Parser::query(is_tmux, options);
+    // `Parser::query` already wrote the shared memory probe's object (if any) before
+    // naming it in the query, since the terminal must be able to open it the moment
+    // it reads the escape. Kitty/Ghostty unlink it themselves once they've read it,
+    // so this guard is for every other outcome — ignored, refused, or never
+    // answered — which would otherwise leave it behind for the life of the machine.
+    #[cfg(not(windows))]
+    let _unlink_shm_probe = shm_probe_name.map(ShmProbeUnlink);
+    #[cfg(windows)]
+    let _ = shm_probe_name;
+
     io::stdout().write_all(query.as_bytes())?;
     io::stdout().flush()?;
 
@@ -528,6 +553,24 @@ fn query_stdio_capabilities(
     Ok(())
 }
 
+/// Unlinks the named shared memory object when dropped.
+///
+/// `Parser::query` writes and names the shared-memory probe's object before this
+/// side ever sees the terminal's answer, so cleanup lives here rather than in the
+/// query builder: kitty/Ghostty unlink an object once they've read it, so a gone
+/// object at drop time is the success case, not an error (`ENOENT` is ignored) —
+/// this guard exists for every other outcome, where the terminal ignored,
+/// refused, or never answered the probe at all.
+#[cfg(not(windows))]
+struct ShmProbeUnlink(String);
+
+#[cfg(not(windows))]
+impl Drop for ShmProbeUnlink {
+    fn drop(&mut self) {
+        let _ = rustix::shm::unlink(self.0.as_str());
+    }
+}
+
 fn interpret_parser_responses(
     responses: Vec<Response>,
 ) -> Result<(Option<ProtocolType>, Option<FontSize>, Vec<Capability>)> {
@@ -556,6 +599,7 @@ fn interpret_parser_responses(
             }
             Response::RectangularOps => Some(Capability::RectangularOps),
             Response::KittyCompression => Some(Capability::KittyCompression),
+            Response::KittySharedMemory => Some(Capability::KittySharedMemory),
             Response::CellSize(cell_size) => {
                 if let Some((w, h)) = cell_size {
                     font_size = Some((*w, *h).into());
@@ -651,10 +695,59 @@ mod tests {
 
     use crate::{
         FontSize,
-        picker::{Capability, Picker, ProtocolType},
+        picker::{Capability, Picker, ProtocolType, cap_parser::QueryStdioOptions},
     };
 
     use super::{cap_parser::Response, fallback_picker, interpret_parser_responses};
+
+    /// Exercises the query-side probe end to end: `Parser::query` writes a real
+    /// object and names it in the escape, and `ShmProbeUnlink` — the guard
+    /// `query_stdio_capabilities` wraps the name in — is what's responsible for
+    /// cleaning it up afterward. The object has to actually exist while the
+    /// guard is alive and actually be gone once it drops, not just the string
+    /// plumbing between the two.
+    #[test]
+    #[cfg(not(windows))]
+    fn test_shm_probe_round_trips() {
+        use super::ShmProbeUnlink;
+
+        let (_query, name) = super::cap_parser::Parser::query(
+            false,
+            QueryStdioOptions {
+                kitty_shared_memory_object: Some(std::process::id()),
+                ..Default::default()
+            },
+        );
+        let name = name.expect("this platform writes shared memory");
+
+        let fd = rustix::shm::open(
+            name.as_str(),
+            rustix::shm::OFlags::RDONLY,
+            rustix::fs::Mode::empty(),
+        )
+        .expect("the object exists before the guard has dropped");
+        // At least the one RGBA pixel `f=32,s=1,v=1` promises, since a terminal
+        // rejects an object smaller than `s * v * bpp`. Not exactly: macOS rounds
+        // a shared memory object up to a page, so this reads 16384 there and 4 on
+        // Linux, and only the floor is a portable claim.
+        let size = rustix::fs::fstat(&fd).expect("stat the object").st_size;
+        assert!(
+            size >= 4,
+            "the probe object holds one RGBA pixel, got {size}"
+        );
+        drop(fd);
+
+        drop(ShmProbeUnlink(name.clone()));
+        assert!(
+            rustix::shm::open(
+                name.as_str(),
+                rustix::shm::OFlags::RDONLY,
+                rustix::fs::Mode::empty(),
+            )
+            .is_err(),
+            "the guard leaves nothing behind for a terminal that never read it"
+        );
+    }
 
     #[test]
     fn test_cycle_protocol() {

--- a/src/picker/cap_parser.rs
+++ b/src/picker/cap_parser.rs
@@ -22,6 +22,7 @@ pub enum Response {
     Sixel,
     RectangularOps,
     KittyCompression,
+    KittySharedMemory,
     CellSize(Option<(u16, u16)>),
     CursorPositionReport(u16, u16),
     Background(u8, u8, u8),
@@ -56,17 +57,36 @@ pub struct QueryStdioOptions {
     /// bottleneck, such as over SSH, and the images compress well (flat
     /// colour, UI, pixel art).
     pub kitty_compression: bool,
-    /// Use POSIX shared memory objects for kitty image transmission instead of inline base64.
+    /// Probe POSIX shared memory objects for kitty image transmission instead of inline base64,
+    /// and use it if available.
     ///
     /// The integer is included in the SHM name (typically the process PID) to make it unique
-    /// across processes. When set, images are written to a named SHM object before the kitty
-    /// escape sequence is emitted, using transmission medium `t=s`.
+    /// across processes. The stdio query writes a one-pixel object under that name and asks the
+    /// terminal to read it back with the protocol's own query action (`a=q`); a terminal running
+    /// on another machine — over ssh, most obviously — cannot open it, so
+    /// [`crate::picker::Capability::KittySharedMemory`] is reported only where the terminal
+    /// answered `OK`. From then on, real images are written to a freshly named SHM object per
+    /// transmission before the kitty escape sequence is emitted, using transmission medium `t=s`.
+    ///
+    /// **Shared memory is used only when that probe answered `OK`, never otherwise.** No answer —
+    /// a terminal that ignores `a=q`, one that never receives the kitty query at all (the
+    /// blacklisted protocols), an object that could not be created — means inline base64,
+    /// exactly as if this field were `None`. tmux is not one of those cases: the query already
+    /// travels through its passthrough, so the probe reaches the outer terminal. "Could not probe"
+    /// and "the terminal cannot open our memory" are indistinguishable from this side, and the
+    /// second is the ssh case, where an unprobed `t=s` transmit draws nothing at all; so there is
+    /// deliberately no fallback to using the object unprobed.
     ///
     /// See <https://sw.kovidgoyal.net/kitty/graphics-protocol/#the-transmission-medium>.
     ///
-    /// No cleanup of the SHM object is performed on this side — kitty is responsible for
-    /// unlinking it after reading. Untransmitted kitty images must be manually cleaned up by the
-    /// user.
+    /// The probe's own object is unlinked once its replies are read, regardless of the terminal's
+    /// answer. For a real transmit, no cleanup is performed on this side beyond that — kitty is
+    /// responsible for unlinking it after reading. An image transmit the caller never consumes
+    /// with a render (dropped frames in a threaded caller, say) leaves its object behind to be
+    /// cleaned up by hand, the same way an untransmitted base64 image is left marked transmitted
+    /// but never shown.
+    ///
+    /// Windows accepts the option and never reports the capability.
     pub kitty_shared_memory_object: Option<u32>,
 }
 
@@ -110,11 +130,18 @@ impl Parser {
         }
     }
 
-    pub fn query(is_tmux: bool, options: QueryStdioOptions) -> String {
+    /// Build the stdio query. Returns the query itself, and — where
+    /// [`QueryStdioOptions::kitty_shared_memory_object`] led to a real probe object being
+    /// created — that object's name, so the caller can unlink it once the query's replies have
+    /// been read (see [`QueryStdioOptions::kitty_shared_memory_object`]'s doc for why this side
+    /// must clean it up rather than leaving it to the terminal).
+    pub fn query(is_tmux: bool, options: QueryStdioOptions) -> (String, Option<String>) {
         let (start, escape, end) = Parser::tmux_start_escape_end(is_tmux);
 
         let mut buf = String::with_capacity(100);
         buf.push_str(start);
+
+        let mut shm_probe_name = None;
 
         if !options.blacklist_protocols.contains(&ProtocolType::Kitty) {
             // Kitty graphics
@@ -131,6 +158,28 @@ impl Parser {
                     "{escape}_Gi=32,s=1,v=1,a=q,t=d,f=24,o=z;{PROBE}{escape}\\"
                 )
                 .unwrap();
+            }
+
+            // Kitty shared memory transmission: probed by writing the SAME one RGBA
+            // pixel a real `t=s` transmit would, through the same two primitives
+            // (`kitty::shm_name` + `kitty::shm_write`) a real transmit uses — not
+            // `kitty::transmit_shm` itself, since that builds a real `a=T` display
+            // escape and this probe needs the protocol's own `a=q` query shape
+            // wrapped around the same object instead. Its own image id (33) tells
+            // the reply apart from the others, and the payload is the object's NAME
+            // rather than its contents. A successful reply adds `KittySharedMemory`
+            // to the capabilities; the object itself is unlinked by the caller once
+            // the query's replies are read.
+            #[cfg(not(windows))]
+            if let Some(shm_id) = options.kitty_shared_memory_object {
+                const PIXEL: [u8; 4] = [0, 0, 0, 0];
+                let name = crate::protocol::kitty::shm_name(shm_id, rand::random());
+                if crate::protocol::kitty::shm_write(&name, &PIXEL).is_ok() {
+                    write!(buf, "{escape}_Gi=33,s=1,v=1,a=q,t=s,f=32;").unwrap();
+                    base64_simd::STANDARD.encode_append(name.as_bytes(), &mut buf);
+                    write!(buf, "{escape}\\").unwrap();
+                    shm_probe_name = Some(name);
+                }
             }
         }
 
@@ -172,7 +221,7 @@ impl Parser {
         write!(buf, "{escape}[5n").unwrap();
 
         write!(buf, "{end}").unwrap();
-        buf
+        (buf, shm_probe_name)
     }
 
     pub fn push(&mut self, next: char) -> Vec<Response> {
@@ -183,7 +232,7 @@ impl Parser {
                         // If the current sequence hasn't been identified yet, start a new one on Esc.
                         return self.restart();
                     }
-                    ("_Gi=31" | "_Gi=32", ';') => {
+                    ("_Gi=31" | "_Gi=32" | "_Gi=33", ';') => {
                         self.sequence = ResponseParseState::KittyResponse;
                     }
 
@@ -286,6 +335,7 @@ impl Parser {
                     let caps = match &self.data[..] {
                         "_Gi=31;OK\x1b" => vec![Response::Kitty],
                         "_Gi=32;OK\x1b" => vec![Response::KittyCompression],
+                        "_Gi=33;OK\x1b" => vec![Response::KittySharedMemory],
                         _ => vec![],
                     };
                     self.restart();
@@ -380,7 +430,7 @@ mod tests {
     /// ever appear where the probe was sent.
     #[test]
     fn test_query_omits_compression_probe_by_default() {
-        let q = Parser::query(false, QueryStdioOptions::default());
+        let (q, _) = Parser::query(false, QueryStdioOptions::default());
         assert!(
             !q.contains("_Gi=32"),
             "the compression probe must be opt-in: {q}"
@@ -392,7 +442,7 @@ mod tests {
     /// but cannot inflate would drop every compressed image on the floor.
     #[test]
     fn test_query_carries_a_compressed_probe_when_opted_in() {
-        let q = Parser::query(
+        let (q, _) = Parser::query(
             false,
             QueryStdioOptions {
                 kitty_compression: true,
@@ -434,6 +484,95 @@ mod tests {
     fn test_parse_compression_refused() {
         assert_eq!(
             parse("\x1b_Gi=31;OK\x1b\\\x1b_Gi=32;EINVAL:bad\x1b\\\x1b[0n"),
+            vec![Response::Kitty, Response::Status],
+        );
+    }
+
+    /// The shared memory probe is off by default, so
+    /// `Capability::KittySharedMemory` can only ever appear where the probe was
+    /// sent, and no object is created to clean up either.
+    #[test]
+    fn test_query_omits_shared_memory_probe_by_default() {
+        let (q, name) = Parser::query(false, QueryStdioOptions::default());
+        assert!(
+            !q.contains("_Gi=33"),
+            "the shared memory probe must be opt-in: {q}"
+        );
+        assert_eq!(name, None, "nothing was created, so nothing to clean up");
+    }
+
+    /// The shared memory probe is the kitty probe with `t=s`, and its payload is
+    /// the NAME of a real object this call just wrote a pixel into — not a
+    /// placeholder — rather than pixels: a terminal on another machine cannot
+    /// open it, which is the whole point of asking. `query` hands the name back
+    /// so the caller can clean it up once the replies are read (see
+    /// `QueryStdioOptions::kitty_shared_memory_object`'s doc).
+    #[test]
+    #[cfg(not(windows))]
+    fn test_query_shared_memory_probe_writes_a_real_object_for_cleanup() {
+        let pid = std::process::id();
+        let (q, name) = Parser::query(
+            false,
+            QueryStdioOptions {
+                kitty_shared_memory_object: Some(pid),
+                ..Default::default()
+            },
+        );
+        let name = name.expect("this platform writes shared memory");
+
+        let (_, rest) = q
+            .split_once("\x1b_Gi=33,s=1,v=1,a=q,t=s,f=32;")
+            .expect("the shared memory probe is in the query");
+        let (payload, _) = rest.split_once("\x1b\\").expect("the probe is terminated");
+        let decoded = base64_simd::STANDARD
+            .decode_to_vec(payload)
+            .expect("the probe payload is base64");
+        let decoded = String::from_utf8(decoded).expect("the probe payload is an object name");
+        assert_eq!(
+            decoded, name,
+            "the escape names the exact object this call created"
+        );
+        assert!(
+            name.starts_with(&format!("/rtui-{pid}-")),
+            "the same prefix a real transmit uses: {name}"
+        );
+
+        // The object is real, and holds the one RGBA pixel the probe promises
+        // (`f=32,s=1,v=1`) — not merely a name nothing backs.
+        let fd = rustix::shm::open(
+            name.as_str(),
+            rustix::shm::OFlags::RDONLY,
+            rustix::fs::Mode::empty(),
+        )
+        .expect("the query wrote the object before naming it");
+        let size = rustix::fs::fstat(&fd).expect("stat the object").st_size;
+        assert!(size >= 4, "one RGBA pixel, got {size} bytes");
+        drop(fd);
+
+        // `query` only writes; cleanup is the caller's job (`Picker` unlinks it
+        // once the query's replies are read). Play that part here.
+        rustix::shm::unlink(name.as_str()).expect("the caller can unlink what query wrote");
+    }
+
+    #[test]
+    fn test_parse_shared_memory_response() {
+        assert_eq!(
+            parse("\x1b_Gi=31;OK\x1b\\\x1b_Gi=33;OK\x1b\\\x1b[0n"),
+            vec![
+                Response::Kitty,
+                Response::KittySharedMemory,
+                Response::Status
+            ],
+        );
+    }
+
+    /// A terminal that cannot reach the object — anything remote — answers with
+    /// an error, and must yield no capability: transmitting to it anyway would
+    /// draw nothing at all.
+    #[test]
+    fn test_parse_shared_memory_refused() {
+        assert_eq!(
+            parse("\x1b_Gi=31;OK\x1b\\\x1b_Gi=33;EBADF:no such file\x1b\\\x1b[0n"),
             vec![Response::Kitty, Response::Status],
         );
     }

--- a/src/protocol/kitty.rs
+++ b/src/protocol/kitty.rs
@@ -10,16 +10,19 @@ use std::fmt::Write;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[cfg(not(any(windows, target_os = "linux")))]
+use rustix::mm::{MapFlags, ProtFlags, mmap, munmap};
 #[cfg(not(windows))]
 use rustix::{
     fs::Mode,
-    io::write as rustix_write,
     shm::{self, OFlags as ShmOFlags},
 };
 
 use crate::protocol::UNIT_WIDTH;
 use crate::{Result, picker::cap_parser::Parser};
 use image::DynamicImage;
+#[cfg(not(windows))]
+use rand::random;
 use ratatui::buffer::CellDiffOption;
 use ratatui::layout::Size;
 use ratatui::{buffer::Buffer, layout::Rect};
@@ -41,7 +44,19 @@ impl KittyProtoState {
         compress: bool,
         shm_pid: Option<u32>,
     ) -> Result<Self> {
-        let transmit_str = transmit_or_shm(img, id, is_tmux, compress, shm_pid)?;
+        // The only caller that holds a `DynamicImage`: every transmit path below
+        // takes raw RGBA bytes plus dimensions, so the conversion happens once,
+        // here, rather than once per path.
+        let img_rgba8 = img.to_rgba8();
+        let transmit_str = transmit_or_shm(
+            img_rgba8.as_raw(),
+            img.width(),
+            img.height(),
+            id,
+            is_tmux,
+            compress,
+            shm_pid,
+        )?;
         let [id_extra, id_r, id_g, id_b] = id.to_be_bytes();
         let id_color = format!("\x1b[38;2;{id_r};{id_g};{id_b}m");
         let id_extra = u16::from(id_extra);
@@ -258,7 +273,9 @@ fn zlib(raw: &[u8]) -> Vec<u8> {
 }
 
 fn transmit_or_shm(
-    img: &DynamicImage,
+    bytes: &[u8],
+    w: u32,
+    h: u32,
     id: u32,
     is_tmux: bool,
     compress: bool,
@@ -266,34 +283,148 @@ fn transmit_or_shm(
 ) -> Result<String> {
     #[cfg(not(windows))]
     if let Some(pid) = shm_pid {
-        return transmit_shm(img, id, pid, is_tmux);
+        return transmit_shm(bytes, w, h, id, pid, is_tmux);
     }
-    Ok(transmit_virtual(img, id, is_tmux, compress))
+    Ok(transmit_base64(bytes, w, h, id, is_tmux, compress))
+}
+
+/// Create a shared memory object of exactly `bytes.len()` and fill it.
+///
+/// **Linux writes through the descriptor.** `write(2)` on a POSIX shared memory
+/// object allocates the `tmpfs` pages it touches inside the syscall itself —
+/// unlike `ftruncate`, which only names a length and lets `tmpfs` allocate on
+/// first touch — so there is nothing to reserve up front and no mapping to make:
+/// an object bigger than the space left in `/dev/shm` (64 MB by default in a
+/// Docker container) answers `write_all` with an ordinary `io::Error` — `ENOSPC`,
+/// or a short write — which the caller already turns into a fallback like any
+/// other failure. `ftruncate` is unnecessary too, since the write itself sets the
+/// object's length. `shm::open` hands back an `OwnedFd`, and `File`'s `From`
+/// impl for it needs no `unsafe` at all.
+///
+/// The object still ends up sized to exactly the payload — a terminal rejects one
+/// smaller than `s * v * bpp` (Ghostty: "shared memory size too small") — which
+/// falls out of writing exactly `bytes.len()` bytes to a fresh object.
+///
+/// Linux is the one target with its own function because it is the one target
+/// where mapping a shared memory object can fail at runtime instead of at open
+/// time: a mapping that outruns a `tmpfs` short on pages faults with `SIGBUS` on
+/// first touch, past any `Result` this crate could hand back. `write(2)` turns
+/// the same shortage into an ordinary `io::Error` instead, so Linux writes and
+/// every other Unix maps (see this function's twin below).
+#[cfg(target_os = "linux")]
+pub(crate) fn shm_write(name: &str, bytes: &[u8]) -> Result<()> {
+    use std::io::Write as _;
+
+    let fd = shm::open(
+        name,
+        ShmOFlags::CREATE | ShmOFlags::RDWR | ShmOFlags::TRUNC,
+        Mode::RUSR | Mode::WUSR,
+    )?;
+    std::fs::File::from(fd).write_all(bytes)?;
+    Ok(())
+}
+
+/// Create a shared memory object of exactly `bytes.len()` and fill it.
+///
+/// **Every non-Linux Unix goes in through a mapping instead of `write(2)`.**
+/// `mmap` is the one operation POSIX actually promises on a shared memory
+/// object; `write` is a per-kernel courtesy on top of it, and this crate has
+/// already met both ends of that: macOS refuses it outright with `ENXIO`
+/// (there is no read/write path on its shared memory objects at all), while
+/// FreeBSD happens to allow it but is untested here. Mapping is also what the
+/// terminal itself uses to read the object back, so this is the operation
+/// every reader on these platforms is already relying on. `ftruncate` alone
+/// reserves what it names — these objects are ordinary anonymous memory with
+/// no separate `tmpfs` quota to run out of the way Linux's can (see the
+/// `target_os = "linux"` twin of this function, above, for why Linux writes
+/// instead). The cfg spells "every Unix but Linux", not "macOS": the crate
+/// draws no line between the rest anywhere else, and this function shouldn't
+/// either.
+///
+/// The object is sized to exactly the payload, since a terminal rejects one
+/// smaller than `s * v * bpp` (Ghostty: "shared memory size too small").
+#[cfg(not(any(windows, target_os = "linux")))]
+pub(crate) fn shm_write(name: &str, bytes: &[u8]) -> Result<()> {
+    let fd = shm::open(
+        name,
+        ShmOFlags::CREATE | ShmOFlags::RDWR | ShmOFlags::TRUNC,
+        Mode::RUSR | Mode::WUSR,
+    )?;
+    rustix::fs::ftruncate(&fd, bytes.len() as u64)?;
+    // SAFETY: a fresh mapping of a descriptor we just created and sized to
+    // `bytes.len()`, written once and unmapped before it can be aliased.
+    unsafe {
+        let ptr = mmap(
+            std::ptr::null_mut(),
+            bytes.len(),
+            ProtFlags::READ | ProtFlags::WRITE,
+            MapFlags::SHARED,
+            &fd,
+            0,
+        )?;
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr.cast::<u8>(), bytes.len());
+        munmap(ptr, bytes.len())?;
+    }
+    Ok(())
+}
+
+/// The name of the shared memory object one TRANSMIT is handed over in.
+///
+/// Short on purpose. POSIX only promises 14 bytes and Linux allows 255, but macOS
+/// caps the whole name at 31 bytes including the leading slash (`PSHMNAMLEN`), and
+/// anything longer is refused with `ENAMETOOLONG` — measured on macOS 15, where
+/// `/ratatui-image-kitty-shm12345-4294967295` never opens at all. A refused
+/// transmit is silent: the image is never stored, and every placement naming it
+/// draws nothing. So the name has to fit the smallest limit we ship on, which at
+/// u32's widest this does exactly.
+///
+/// `serial` is not the kitty image id — see [`transmit_shm`] for why the two must
+/// not be conflated. `pub(crate)` so the shared-memory probe in
+/// [`crate::picker::cap_parser`] can name its own object the same way a real
+/// transmit does, without going through the display escape [`transmit_shm`]
+/// builds around it (the probe's query escape is a different shape).
+#[cfg(not(windows))]
+pub(crate) fn shm_name(shm_pid: u32, serial: u32) -> String {
+    format!("/rtui-{shm_pid}-{serial}")
 }
 
 /// Transmit via POSIX shared memory object (t=s).
 ///
 /// Writes raw RGBA pixels into a named SHM object, then emits a single kitty APC chunk
-/// pointing at it. The SHM object is intentionally left alive for kitty to unlink.
+/// pointing at it. The SHM object is intentionally left alive for kitty to unlink —
+/// and if the caller never consumes this transmit with a render (a dropped frame in
+/// a threaded caller, say), that object is left for the caller to clean up by hand,
+/// the same way an untransmitted base64 image is left marked transmitted but never
+/// shown.
+///
+/// **The object is named from a per-transmit random suffix, never from the kitty
+/// image id, and never from a second counter either.** `id` is stable across
+/// re-transmits of the same picture — deliberately, a caller such as
+/// [`StatefulKitty::resize_encode`] or a `new_protocol_with_id` caller reuses it
+/// exactly so a placement need not be rebuilt — but the object handover is
+/// ASYNCHRONOUS in a way the escape stream itself is not: a repeated base64
+/// transmit under one `id` is harmless, because the wire is ordered and the
+/// terminal simply replaces the image when it gets to the second one. A repeated
+/// shm NAME is not, because the terminal opens and reads that object whenever it
+/// next gets to it, independent of when the next transmit runs; naming the object
+/// after `id` would let a second transmit recreate (`O_CREAT|O_TRUNC`) the very
+/// object the terminal may still be midway through reading for the first one, so
+/// it finds truncated bytes, the wrong frame's bytes, or nothing at all (Ghostty
+/// answers with "shared memory size too small" and drops the frame). `rand::random`
+/// serves the suffix precisely because [`crate::picker::Picker`] already draws
+/// kitty image ids the same way — no second atomic earns its keep for one more
+/// number in the same space.
 #[cfg(not(windows))]
-fn transmit_shm(img: &DynamicImage, id: u32, shm_pid: u32, is_tmux: bool) -> Result<String> {
-    let (w, h) = (img.width(), img.height());
-    let img_rgba8 = img.to_rgba8();
-    let bytes = img_rgba8.as_raw();
-
-    let shm_name = format!("/ratatui-image-kitty-shm{shm_pid}-{id}");
-
-    let fd = shm::open(
-        &shm_name,
-        ShmOFlags::CREATE | ShmOFlags::RDWR | ShmOFlags::TRUNC,
-        Mode::RUSR | Mode::WUSR,
-    )?;
-    rustix::fs::ftruncate(&fd, bytes.len() as u64)?;
-    let mut offset = 0;
-    while offset < bytes.len() {
-        offset += rustix_write(&fd, &bytes[offset..])?;
-    }
-    drop(fd);
+fn transmit_shm(
+    bytes: &[u8],
+    w: u32,
+    h: u32,
+    id: u32,
+    shm_pid: u32,
+    is_tmux: bool,
+) -> Result<String> {
+    let shm_name = shm_name(shm_pid, random());
+    shm_write(&shm_name, bytes)?;
 
     let (start, escape, end) = Parser::tmux_start_escape_end(is_tmux);
 
@@ -331,14 +462,11 @@ fn transmit_shm(img: &DynamicImage, id: u32, shm_pid: u32, is_tmux: bool) -> Res
 /// `compress` must only be set when the terminal answered the `o=z` capability
 /// probe: a terminal that cannot inflate refuses the transmission outright, and
 /// every placement naming the image then draws nothing at all.
-fn transmit_virtual(img: &DynamicImage, id: u32, is_tmux: bool, compress: bool) -> String {
-    let (w, h) = (img.width(), img.height());
-    let img_rgba8 = img.to_rgba8();
-    let raw = img_rgba8.as_raw();
+fn transmit_base64(bytes: &[u8], w: u32, h: u32, id: u32, is_tmux: bool, compress: bool) -> String {
     let bytes: Cow<[u8]> = if compress {
-        Cow::Owned(zlib(raw))
+        Cow::Owned(zlib(bytes))
     } else {
-        Cow::Borrowed(raw)
+        Cow::Borrowed(bytes)
     };
     let compression = if compress { "o=z," } else { "" };
 
@@ -694,7 +822,7 @@ fn diacritic(y: u16) -> char {
 
 #[cfg(test)]
 mod tests {
-    use super::transmit_virtual;
+    use super::transmit_base64;
     use image::{DynamicImage, RgbaImage};
 
     fn canvas() -> DynamicImage {
@@ -737,7 +865,15 @@ mod tests {
     #[test]
     fn transmit_without_compression_is_the_raw_image() {
         let img = canvas();
-        let (params, bytes) = reassemble(&transmit_virtual(&img, 7, false, false));
+        let raw = img.to_rgba8();
+        let (params, bytes) = reassemble(&transmit_base64(
+            raw.as_raw(),
+            img.width(),
+            img.height(),
+            7,
+            false,
+            false,
+        ));
         assert!(
             !params.contains("o=z"),
             "nothing claims to be compressed: {params}"
@@ -757,7 +893,15 @@ mod tests {
     #[test]
     fn transmit_with_compression_inflates_back_to_the_raw_image() {
         let img = canvas();
-        let (params, bytes) = reassemble(&transmit_virtual(&img, 7, false, true));
+        let raw = img.to_rgba8();
+        let (params, bytes) = reassemble(&transmit_base64(
+            raw.as_raw(),
+            img.width(),
+            img.height(),
+            7,
+            false,
+            true,
+        ));
         assert!(
             params.contains("o=z"),
             "the payload is compressed and says so: {params}"
@@ -775,7 +919,6 @@ mod tests {
             "`S` is for PNG-plus-compression, and this is f=32"
         );
 
-        let raw = img.to_rgba8();
         assert!(
             bytes.len() < raw.as_raw().len(),
             "{} vs {}",
@@ -786,5 +929,64 @@ mod tests {
         std::io::copy(&mut flate2::read::ZlibDecoder::new(&bytes[..]), &mut out)
             .expect("the whole payload is one zlib stream");
         assert_eq!(out, *raw.as_raw());
+    }
+
+    /// macOS refuses a shared memory name longer than 31 bytes, and a refused
+    /// transmit draws nothing rather than saying so — so the widest name the
+    /// scheme can produce has to fit, not merely a typical one. The serial is a
+    /// `u32` exactly so this stays true: a `u64` serial's widest value would blow
+    /// the budget the pid alone already spends most of.
+    #[test]
+    #[cfg(not(windows))]
+    fn shm_names_fit_the_tightest_platform_limit() {
+        const PSHMNAMLEN: usize = 31;
+        let widest = super::shm_name(u32::MAX, u32::MAX);
+        assert!(
+            widest.len() <= PSHMNAMLEN,
+            "`{widest}` is {} bytes, macOS allows {PSHMNAMLEN}",
+            widest.len()
+        );
+        assert!(
+            widest.starts_with('/') && !widest[1..].contains('/'),
+            "one leading slash and no others, for portability: {widest}"
+        );
+    }
+
+    /// Two transmits of the SAME image id must still land in two different
+    /// objects — that is the entire fix: the terminal owns the first object
+    /// asynchronously from the moment its escape is written, and a second
+    /// transmit reusing that name would recreate it out from under a reader that
+    /// has not gotten to it yet. See [`super::transmit_shm`]'s doc comment.
+    #[test]
+    #[cfg(not(windows))]
+    fn consecutive_shm_transmits_of_the_same_id_use_different_objects() {
+        let img = canvas();
+        let raw = img.to_rgba8();
+        let pid = std::process::id();
+        let first = super::transmit_shm(raw.as_raw(), img.width(), img.height(), 7, pid, false)
+            .expect("this platform writes shared memory");
+        let second = super::transmit_shm(raw.as_raw(), img.width(), img.height(), 7, pid, false)
+            .expect("this platform writes shared memory");
+
+        let name_of = |seq: &str| {
+            let start = seq.find(";").expect("payload starts after the header") + 1;
+            let end = seq.rfind("\x1b\\").expect("the ST ends the payload");
+            let name = base64_simd::STANDARD
+                .decode_to_vec(&seq[start..end])
+                .expect("the payload is base64");
+            String::from_utf8(name).expect("the object name is ASCII")
+        };
+        let (first_name, second_name) = (name_of(&first), name_of(&second));
+        assert_ne!(
+            first_name, second_name,
+            "same image id (7), but the object name must still differ so the second \
+             transmit can never touch an object the terminal may still be reading \
+             from the first: {first_name:?} vs {second_name:?}"
+        );
+
+        // Clean up: a successful `t=s` transmit is left for the terminal to
+        // unlink, which nothing here plays the part of.
+        let _ = rustix::shm::unlink(first_name);
+        let _ = rustix::shm::unlink(second_name);
     }
 }


### PR DESCRIPTION
Onto #198, per your "we should always probe if possible" — plus two platform fixes without which `t=s` never transmits anything on macOS, a naming fix for a race the async handover opens up, and a Linux write path that sidesteps the reservation problem entirely rather than guarding it. One commit, four parts; the macOS part is the one to look at first. Revised per review — see the four points below the fold for what changed.

## 1. Making the transmit work on macOS

Both of these are measured on macOS 26.6 (Apple Silicon), and both are invisible when they happen: the transmit fails, the image is never stored, and every unicode placeholder naming it draws nothing.

**The name is too long.** macOS caps a POSIX shared memory name at **31 bytes including the leading slash** (`PSHMNAMLEN`), and refuses anything longer with `ENAMETOOLONG`. `/ratatui-image-kitty-shm` is 24 bytes before the numbers start, so `/ratatui-image-kitty-shm4242-1234567890` — an entirely ordinary pid and image id — never opens. Linux allows 255 and is perfectly happy with the same name, which is why this only shows up on one platform. Measured directly:

```
35 /ratatui-image-kitty-shm12345-probe       -> File name too long
40 /ratatui-image-kitty-shm99999-4294967295  -> File name too long
31 /123456789012345678901234567890           -> ok
32 /1234567890123456789012345678901          -> File name too long
```

The name is now `/rtui-{pid}-{suffix}`, well inside the limit at `u32::MAX` for both parts, with a test asserting the **widest** name the scheme can produce fits — a typical one fitting proves nothing here.

**`write(2)` does not work on a shared memory object there.** The descriptor opens, `ftruncate` succeeds, and the first write answers `ENXIO` ("Device not configured"). macOS simply does not implement read/write on shm objects. The bytes go in through an `mmap`/`copy`/`munmap` instead, which is what the terminal does at the other end anyway. `rustix` gains the `mm` feature; it is already a non-optional dependency on every non-Windows target, so that is one more module, not one more crate. The cfg guarding that path spells "every Unix but Linux" rather than "macOS" — see part 3 for why, and for why that line is drawn there rather than at the one platform I've actually measured it on.

One related note in passing, in case it saves you a puzzling test failure: macOS rounds a shm object up to a page, so after `ftruncate(fd, 4)` an `fstat` reads 16384 there and 4 on Linux. Sizing to exactly the payload is still the right thing — a terminal rejects an object smaller than `s * v * bpp`; Ghostty says "shared memory size too small" — but only the floor is a portable claim.

## 2. Naming the object per transmit, from `rand::random`

The name is keyed off neither the kitty image id nor a second counter. A caller reuses the image id across re-transmits of the same picture on purpose (`StatefulKitty::resize_encode`, or anyone taking an id from `new_protocol_with_id`), so the placement need not be rebuilt — but the object handover is asynchronous in a way the escape stream itself is not. A repeated base64 transmit under one id is harmless, because the wire is ordered and the terminal simply replaces the image when it gets to the second one; a repeated shm *name* is not, because the terminal opens and reads that object whenever it next gets to it, independent of when the next transmit runs. Reusing the id as the name meant a second transmit recreated (`O_CREAT|O_TRUNC`) the very object the terminal might still be midway through reading for the first one, and it found truncated bytes, the wrong frame's bytes, or nothing at all (Ghostty: "shared memory size too small", frame silently dropped). This surfaced downstream in lanthorn as a display freeze on every new line or scroll in a v6 game whose extended graphics mode re-uploads a multi-megabyte composite on each repaint (Zork Zero) — small, infrequent uploads rarely land in the race window, which is why reusing the id looked safe until something uploaded large and often.

Per your note that a second `AtomicU32` didn't earn its keep here: the per-transmit suffix is now `rand::random::<u32>()` — the same way `Picker` already draws kitty image ids — rather than a private counter. `/rtui-{pid}-{suffix}` still means two transmits can never (practically) name the same object; the escape's own `i=` parameter still carries the id the terminal needs to route the pixels to the right placement.

## 3. Writing the object directly, and skipping the mapping (Linux)

`ftruncate` on a tmpfs object reserves nothing: the pages are allocated when first touched, and if `/dev/shm` is full at that moment the kernel does not return an error, it delivers SIGBUS. An earlier revision of this PR closed that with `fallocate` right after `ftruncate`, forcing the reservation up front so a full tmpfs answered `ENOSPC` instead. That is no longer here, because Linux does not need the mapping it was guarding in the first place: `write(2)` on a POSIX shared memory object allocates the pages it touches inside the syscall itself, so a full tmpfs already answers `write_all` with an ordinary `io::Error` — `ENOSPC`, or a short write — with nothing to reserve and nothing that can SIGBUS the process. `ftruncate` becomes unnecessary too, since the write sets the object's length.

So `shm_write` is two `#[cfg]`-gated definitions: `#[cfg(target_os = "linux")]` wraps the descriptor `shm::open` returns in a `std::fs::File` — `shm::open` already hands back an `OwnedFd`, so this needs no `unsafe` at all — and `write_all`s the payload; `#[cfg(not(any(windows, target_os = "linux")))]` keeps the `ftruncate` + `mmap`/`copy`/`munmap` route from part 1, unchanged. That second cfg spells "every Unix but Linux", not "macOS", on your suggestion: `mmap` is the one operation POSIX actually promises on a shared memory object, `write` is a per-kernel courtesy on top of it, and this crate has already met both ends of that split — macOS refuses `write` outright with `ENXIO`, and FreeBSD happens to allow it but I have no way to test it here. The crate draws no line between the rest of the Unixes anywhere else, so this function shouldn't either.

## 4. The probe, revised per your review

`kitty_shared_memory_object` on its own is a blind opt-in, and a blind opt-in to `t=s` is a cliff rather than a slope: a terminal that cannot open the object — anything running on another machine, ssh most obviously — fails the transmission silently. Same shape as the `o=z` cliff in #190. What changed from the first cut, point by point:

* **One option**, not two. `kitty_shared_memory_object: Option<u32>` now means "probe for shared memory during the stdio query, and use it if the terminal answered" — there is no separate `kitty_shared_memory_probe` flag, and the field's doc comment says so up front. `ShmProbe` and `resolve_kitty_shm` are gone; every path through `Picker::from_query_stdio_with_options` — including the one where nothing answered at all — resolves the same way: `if caps.contains(&Capability::KittySharedMemory) { kitty_shm } else { None }`.
* **The probe goes out through the real transmit's own write path.** `transmit_or_shm` now takes raw `(bytes, w, h)` instead of a `DynamicImage`, with `to_rgba8()` hoisted to the one caller that actually holds one; `transmit_virtual` is renamed `transmit_base64` to match. `Parser::query`'s probe writes the same constant one-pixel `[0, 0, 0, 0]` through `kitty::shm_name` + `kitty::shm_write` — the same two primitives `transmit_shm` itself calls — rather than a bespoke deterministic-name scheme. It stops short of calling `transmit_shm` directly, since that builds a real `a=T` display escape and the probe needs the protocol's own `a=q` query shape wrapped around the same object instead; `Gi=33` still tells the reply apart from the others.
* **Cleanup moved with it.** `Parser::query` now returns `(String, Option<String>)` — the query, and the probe object's name where one was created — and `Picker` unlinks it once the query's replies are read, in a small `ShmProbeUnlink` guard. Kitty/Ghostty unlink an object once they've read it, so a gone object at drop time is the success case (`ENOENT` ignored), not an error; the guard is for every other outcome, where the terminal ignored, refused, or never answered the probe at all. If the object can't be created, the probe is simply dropped from the query rather than sent blindly.

Windows accepts the option and never reports the capability — `rustix`'s shm is a non-Windows dependency here, so the probe is `cfg(not(windows))` in the query, in the guard, and in its tests.

One thing that's still true and worth restating since the doc comment moved: if a caller never consumes a real transmit with a render — dropped frames in a threaded caller, say — that transmit's own shm object is left behind for the caller to clean up by hand, the same way an untransmitted base64 image is left marked transmitted but never shown. No code change there, just made explicit in both `kitty_shared_memory_object`'s doc and `transmit_shm`'s.

## Tests

Ten in the existing style: the widest shm name fits macOS's limit; two consecutive transmits of the same image id land in two different objects; the probe is absent, and creates nothing to clean up, from a default query; the opted-in query writes a real object, sized and named exactly as the escape claims; `OK` yields the capability and `EBADF` yields none; and an end-to-end round trip through `Parser::query` and `ShmProbeUnlink` confirms the object exists while the guard is alive and is gone once it drops.

`cargo test`, `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean (locally with `--no-default-features --features image-defaults,crossterm`, since I have no chafa here).

## Tried on a real terminal

Ghostty 1.3.1 on macOS 26.6 answers the probe, and with the capability reported the pictures arrive: a Zork Zero session (Infocom v6, lanthorn's hybrid renderer) put 18 images / 1.5 MB of RGBA through `t=s` with 1,471 bytes on the wire in total, against ~2.1 MB base64'd raw or ~130 KB with `o=z`. Over ssh — a Linux host driven from that same Ghostty — the probe gets no `OK`, the capability is not reported, and the pictures arrive as base64 exactly as before; that is the case the probe exists for. Not yet tried on kitty itself.
