### PR TITLE
fix(kitty): name the virtual placement so a re-transmit replaces it

### DIFF
--- a/src/protocol/kitty.rs
+++ b/src/protocol/kitty.rs
@@ -22,6 +22,12 @@ use super::{ProtocolTrait, StatefulProtocolTrait};
 /// The character kitty reserves for image placeholders.
 const PLACEHOLDER: char = '\u{10EEEE}';
 
+/// The placement id every virtual placement is created under.
+///
+/// Placement ids are scoped to their image, so one constant serves every image;
+/// see [`transmit_virtual`] for why it is stated rather than left at 0.
+const PLACEMENT: u32 = 1;
+
 #[derive(Default, Clone)]
 struct KittyProtoState {
     transmitted: Arc<AtomicBool>,
@@ -223,6 +229,15 @@ fn zlib(raw: &[u8]) -> Vec<u8> {
 /// `compress` must only be set when the terminal answered the `o=z` capability
 /// probe: a terminal that cannot inflate refuses the transmission outright, and
 /// every placement naming the image then draws nothing at all.
+///
+/// The virtual placement is NAMED (`p=PLACEMENT`) rather than left at the
+/// protocol's default of `p=0`, which means "assign me an internal id". An id can
+/// be transmitted to more than once — [`StatefulKitty::resize_encode`] does it on
+/// every resize. The protocol says the old image and all its placements are
+/// then replaced, but a terminal that replaces only the image (Ghostty does)
+/// accumulates one unreachable virtual placement per transmission. A named
+/// placement is replaced in the map instead. The unicode placeholders carry no
+/// placement diacritic and still resolve to it, because it is the only one.
 fn transmit_virtual(img: &DynamicImage, id: u32, is_tmux: bool, compress: bool) -> String {
     let (w, h) = (img.width(), img.height());
     let img_rgba8 = img.to_rgba8();
@@ -259,7 +274,11 @@ fn transmit_virtual(img: &DynamicImage, id: u32, is_tmux: bool, compress: bool) 
         write!(data, "{escape}_Gq=2,").unwrap();
 
         if i == 0 {
-            write!(data, "i={id},a=T,U=1,f=32,{compression}t=d,s={w},v={h},").unwrap();
+            write!(
+                data,
+                "i={id},p={PLACEMENT},a=T,U=1,f=32,{compression}t=d,s={w},v={h},"
+            )
+            .unwrap();
         }
 
         // m=0 means over
@@ -774,6 +793,11 @@ mod tests {
         assert!(
             params.contains("f=32") && params.contains("s=64,v=32"),
             "{params}"
+        );
+        assert!(
+            params.contains("p=1,"),
+            "the virtual placement is NAMED, so a re-transmission to this id replaces it \
+             rather than piling up a second one: {params}"
         );
         assert_eq!(bytes, *img.to_rgba8().as_raw());
     }


### PR DESCRIPTION
Names the virtual placement created in `transmit_virtual` (`p=1` instead of the protocol's default `p=0`, meaning "assign an internal id"), so a re-transmission to a live image id replaces the existing placement rather than potentially stranding a duplicate of it.

`StatefulKitty::resize_encode` already re-transmits to the same image id on every terminal resize. Per the kitty graphics protocol spec, transmitting again under a live id is supposed to replace the old image and all of its placements. In practice terminals differ on this: some (Ghostty, for example) replace only the image data and leave the previously-created placement in place, so an unnamed placement accumulates one unreachable duplicate per resize. A named placement is looked up and replaced in the terminal's placement map instead of implicitly re-assigned a new one, so the resize case is handled correctly everywhere regardless of how a given terminal treats an unnamed re-transmit. The unicode placeholder cells don't carry a placement diacritic, so they still resolve fine — there's only one placement to resolve to.

This surfaced while working on lanthorn, a terminal interactive-fiction interpreter that resizes its Kitty-backed image on terminal resize; repeated resizes against Ghostty were piling up orphaned placements.

Tested with `cargo test` (extended the existing `transmit_without_compression_is_the_raw_image` test to pin `p=1,` in the emitted escape sequence), `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --all -- --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Fp2NeopiiiPPLimvsnt4Y
